### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -8,9 +8,5 @@
 	"updateUrl": "",
 	"authors": ["Michiyo"],
 	"credits": "Michiyo",
-	"logoFile": "",
-	"requiredMods": [ "Forge" ],
-	"dependencies": [ "OpenComputers" ],
-	"dependants": [ ],
-	"useDependencyInformation": "true"
+	"logoFile": ""
 }]


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.